### PR TITLE
Add proxmox_lxc_api_node; minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ The hostname of your Proxmox instance.
 The credentials for the API user on the Proxmox instance. If you use PAM to authenticate, make sure to append `@pam` to
 the username. You should define these variables in your local repository and encrypt it using Ansible Vault.
 
-    proxmox_lxc_hostname:
+    - hostname:
 
-Hostname of the LXC that will be created/deleted.
+Hostname of the LXC that will be created/deleted. Must be passed to `proxmox_lxc_containers_present`/
+`proxmox_lxc_containers_absent`.
 
     proxmox_lxc_ostemplate:
 
@@ -71,6 +72,12 @@ possible variables and check the example playbook. For the absent container list
 
 The name of the Proxmox node. Defaults to `proxmox_lxc_api_host`. You might want to change this if you have multiple
 nodes in your cluster.
+
+    proxmox_lxc_api_node: "{{ proxmox_lxc_api_host }}"
+
+The FQDN for the Proxmox node that you want to target. This is used for delegating the "Ping outside" task and therefore
+must be resolvable by Ansible. It's handy in situations where your Proxmode node isn't resolvable with the same name
+that it has within the Proxmox cluster (see [#4](https://github.com/bellackn/ansible-role-proxmox-lxc/issues/4)).
 
     proxmox_lxc_cores: 1
     proxmox_lxc_cpus: 1
@@ -112,8 +119,7 @@ defined.
 
 Seconds to wait for the LXC to be started.
 
-    proxmox_lxc_containers_present:
-      vmid:
+    - vmid:
 
 You can specify the VMID for the container that you want to create. If you don't set this, the next available ID will
 be automatically picked. If the specified ID is already taken, the play will fail.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,13 @@
 ---
+#proxmox_lxc_api_host:
+#proxmox_lxc_api_user:
+#proxmox_lxc_api_password:
+
+proxmox_lxc_api_node: "{{ proxmox_lxc_api_host }}"
+
 proxmox_lxc_containers_present: []
 proxmox_lxc_containers_absent: []
-proxmox_lxc_ostemplate:
+proxmox_lxc_ostemplate: ""
 
 proxmox_lxc_cores: 1
 proxmox_lxc_cpus: 1

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
-#proxmox_lxc_api_host:
-#proxmox_lxc_api_user:
-#proxmox_lxc_api_password:
+# proxmox_lxc_api_host:
+# proxmox_lxc_api_user:
+# proxmox_lxc_api_password:
 
 proxmox_lxc_api_node: "{{ proxmox_lxc_api_host }}"
 

--- a/tasks/create_lxc.yml
+++ b/tasks/create_lxc.yml
@@ -5,7 +5,7 @@
   when:
     - item.netif is defined
     - "'ip=dhcp' not in item.netif"  # We don't know the IP address when DHCP is used
-    - not item.netif | regex_search('ip=(.*?)\/[0-31]')  # If we pass a CIDR range bigger than /32, we also don't know
+    - not item.netif | regex_search('ip=(.*?)\/(?!32)')  # If we pass a CIDR range other than /32, we also don't know
 
 - name: "Create LXC '{{ item.hostname }}'"
   community.general.proxmox:
@@ -65,7 +65,7 @@
 
 - name: Ping outside  # noqa 503
   command: "lxc-attach -n {{ proxmox_lxc_started.msg[3:6] }} -- ping {{ proxmox_lxc_ping_server }} -c 2"
-  delegate_to: "{{ proxmox_lxc_node }}"
+  delegate_to: "{{ proxmox_lxc_api_node }}"
   when:
     - proxmox_lxc_created.changed
     - item.netif is defined


### PR DESCRIPTION
* Add `proxmox_lxc_api_node`; used in `delegate_to` in the "Ping outside" task
* Fix regex when checking for IP address
* Minor fixes in README